### PR TITLE
Fixed yarn config and made fluo-dev ashell accept args

### DIFF
--- a/bin/fluo-dev
+++ b/bin/fluo-dev
@@ -44,21 +44,21 @@ function check_dirs() {
 
 case "$1" in
 download)
-  "$bin"/impl/download.sh ${*:2}
+  "$bin"/impl/download.sh "${@:2}"
 	;;
 setup)
-  "$bin"/impl/setup.sh ${*:2}
+  "$bin"/impl/setup.sh "${@:2}"
 	;;
 deploy)
   check_dirs
-  "$bin"/impl/deploy.sh "${*:2}"
+  "$bin"/impl/deploy.sh "${@:2}"
 	;;
 kill)
-  "$bin"/impl/kill.sh "${*:2}"
+  "$bin"/impl/kill.sh "${@:2}"
 	;;
 ashell)
   check_dirs
-  $ACCUMULO_HOME/bin/accumulo shell -u $ACCUMULO_USER -p $ACCUMULO_PASSWORD
+  $ACCUMULO_HOME/bin/accumulo shell -u $ACCUMULO_USER -p $ACCUMULO_PASSWORD "${@:2}"
 	;;
 *)
 	echo -e "Usage: fluo-dev <command> (<argument>)\n"

--- a/conf/hadoop/capacity-scheduler.xml
+++ b/conf/hadoop/capacity-scheduler.xml
@@ -23,7 +23,7 @@
 
   <property>
     <name>yarn.scheduler.capacity.maximum-am-resource-percent</name>
-    <value>0.1</value>
+    <value>1</value>
     <description>
       Maximum percent of resources in the cluster which can be used to run 
       application masters i.e. controls number of concurrent running


### PR DESCRIPTION
 * Ran into an issue where I could only run one App Master in Yarn.
   This seemed to be cause by yarn config on a single node, so
   updated yarn config.
 * Made this work :  fluo-dev ashell -e 'scan -t stress'.