### PR TITLE
Automatically detect the accumulo version from pom

### DIFF
--- a/bin/impl/setup.sh
+++ b/bin/impl/setup.sh
@@ -29,7 +29,9 @@ function verify_exist_hash() {
   fi
 }
 
-verify_exist_hash $ACCUMULO_TARBALL $ACCUMULO_MD5
+if [ -z "$ACCUMULO_TARBALL_REPO" ]; then
+  verify_exist_hash $ACCUMULO_TARBALL $ACCUMULO_MD5
+fi
 verify_exist_hash $HADOOP_TARBALL $HADOOP_MD5
 verify_exist_hash $ZOOKEEPER_TARBALL $ZOOKEEPER_MD5
 verify_exist_hash $SPARK_TARBALL $SPARK_MD5

--- a/conf/env.sh.example
+++ b/conf/env.sh.example
@@ -45,6 +45,15 @@ export FLUO_TARBALL=fluo-distribution-$FLUO_VERSION-bin.tar.gz
 #
 #export ACCUMULO_TARBALL_REPO=
 
+# Comment out the following if block if you don't want to automatically detect
+# version from the pom.xml. This could be useful if you want to switch branches
+# in your workspace and don't want the detected version to change.
+if [ -n "$ACCUMULO_TARBALL_REPO" ]; then
+  # Detect the version from the accumulo pom.xml in the workspace
+  export ACCUMULO_VERSION=$(xmllint --shell "$ACCUMULO_TARBALL_REPO"/pom.xml <<<'xpath /*[local-name()="project"]/*[local-name()="version"]/text()' | grep content= | cut -f2 -d=)
+  export ACCUMULO_TARBALL=accumulo-$ACCUMULO_VERSION-bin.tar.gz
+fi
+
 # Fluo Tarball
 # ------------
 # Configures how to retrieve/build Fluo distribution tarball used by 'deploy' command.


### PR DESCRIPTION
Adds option to env.sh(.example) to automatically parse the accumulo
version from the pom.xml in the git workspace, if the
ACCUMULO_TARBALL_REPO is configured.